### PR TITLE
fix: lychee verbose config format

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -2,7 +2,7 @@
 # Docs: https://github.com/lycheeverse/lychee#configuration
 
 # Output / behavior
-verbose = true
+verbose = "info"
 no_progress = true
 require_https = true
 max_concurrency = 8


### PR DESCRIPTION
Fixes lychee configuration parsing error by changing verbose from boolean to string format.

This resolves the error in Dependabot PRs where lychee fails with:
```
TOML parse error at line 5, column 11
invalid type: boolean `true`, expected a string
```

Changes:
- Changed `verbose = true` to `verbose = "info"` in lychee.toml
- Maintains same verbosity level while using correct string format